### PR TITLE
remove lines from build.gradle that break in add-to-app

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,27 +1,3 @@
-def localProperties = new Properties()
-def localPropertiesFile = rootProject.file('local.properties')
-if (localPropertiesFile.exists()) {
-    localPropertiesFile.withReader('UTF-8') { reader ->
-        localProperties.load(reader)
-    }
-}
-
-def flutterRoot = localProperties.getProperty('flutter.sdk')
-if (flutterRoot == null) {
-    throw new GradleException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
-}
-
-def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
-if (flutterVersionCode == null) {
-    flutterVersionCode = '1'
-}
-
-def flutterVersionName = localProperties.getProperty('flutter.versionName')
-if (flutterVersionName == null) {
-    flutterVersionName = '1.0'
-}
-
-
 group 'flutter.plugins.screen.screen'
 version '1.0-SNAPSHOT'
 
@@ -51,8 +27,6 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 28
-        versionCode flutterVersionCode.toInteger()
-        versionName flutterVersionName
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     lintOptions {


### PR DESCRIPTION
because add-to-app modules are added into a native codebase where the
`rootProject` is not a flutter app with a local.properties, this breaks
android in add-to-app.

in a brand new `flutter create -t plugin foo`, none of this stuff is in
the build.gradle file.

/domain @mduong @ashleyjoachim @rahobbs @lukesterlee 
/no-platform